### PR TITLE
Add support for multiple short options grouped into a single argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ all: $(TARGETS)
 debug: override CFLAGS += -ggdb -DDEBUG=1 -UNDEBUG
 debug: override OFLAGS := -O0
 debug: override STRIP_FLAGS :=
-debug: $(TARGET)
+debug: $(TARGETS)
 
 # Uses clang's Address Sanitizer to help detect memory errors
 debug+: override CFLAGS += -fsanitize=address
@@ -79,7 +79,7 @@ $(SMALL_TARGET): $(SMALL_OBJS) $(LIB_TARGET)
 	$(_v)$(LD) $(LDFLAGS) $(OFLAGS) $(STRIP_FLAGS) -o $@ $^
 
 # Linking rule for full_example
-$(FULL_TARGET): $(SMALL_OBJS) $(LIB_TARGET)
+$(FULL_TARGET): $(FULL_OBJS) $(LIB_TARGET)
 	@echo 'Linking $@'
 	$(_v)$(LD) $(LDFLAGS) $(OFLAGS) $(STRIP_FLAGS) -o $@ $^
 

--- a/full_example.c
+++ b/full_example.c
@@ -64,6 +64,8 @@ int main(int argc, char** argv) {
 		// You can also have validation logic such as ensuring you can't pass the same flag more than once
 		ARG('o', "once", "This flag may only be set once") {
 			if(once) {
+				printf("Flag --once given multiple times!\n");
+				
 				// Not safe to return from a ARG handler (will leak memory)
 				ret = -1;
 				break;

--- a/kjc_argparse.h
+++ b/kjc_argparse.h
@@ -193,6 +193,7 @@ typedef unsigned char _argtype;
 const static _argtype ARG_TYPE_VOID = 0;
 const static _argtype ARG_TYPE_INT = 1;
 const static _argtype ARG_TYPE_STRING = 2;
+const static _argtype ARG_TYPE_SHORTGROUP = 3;
 
 /* Fields have been hand-packed, hence the weird ordering */
 struct _arginfo {
@@ -217,6 +218,8 @@ struct _argparse {
 	int long_name_width;
 	int long_name_max_width;
 	int has_catchall;
+	unsigned char short_bitmap[32];
+	unsigned char short_value_bitmap[32];
 	_argtype argtype;
 };
 


### PR DESCRIPTION
Add support for parsing arguments like this:

```
ls -laF
./full_example -tHfots stringHere --my-int-argument=42
```